### PR TITLE
Remove `-j` from finish message

### DIFF
--- a/install-parity.sh
+++ b/install-parity.sh
@@ -543,7 +543,7 @@ EOL
 		echo
 		successHeading "All done"
 		head "Next steps"
-		info "Run ${cyan}\`parity -j\`${reset} to start the Parity Ethereum client.${reset}"
+		info "Run ${cyan}\`parity\`${reset} to start the Parity Ethereum client.${reset}"
 		echo
 		exit 0
 	}


### PR DESCRIPTION
The finish message currently says:

```
==> Run `parity -j` to start the Parity Ethereum client.
```

The `-j` can be removed now that JSON-RPC is enabled by default (as of [this commit](https://github.com/ethcore/parity/commit/4dd63c81a63ae8a6bea5183404ecdf224ed5db2a)).
